### PR TITLE
Move rmarkdown logic to common_global so .R can use it

### DIFF
--- a/ftplugin/r_nvimr.vim
+++ b/ftplugin/r_nvimr.vim
@@ -61,13 +61,6 @@ function! RSpin()
     call g:SendCmdToR('require(knitr); .vim_oldwd <- getwd(); setwd("' . expand("%:p:h") . '"); spin("' . expand("%:t") . '"); setwd(.vim_oldwd); rm(.vim_oldwd)')
 endfunction
 
-" Convert R script into Rmd, md and, then, html -- using rmarkdown::render()
-function! RRender()
-    update
-    call g:SendCmdToR('require(rmarkdown); .vim_oldwd <- getwd(); setwd("' . expand("%:p:h") . '"); render("' . expand("%:t") . '"); setwd(.vim_oldwd); rm(.vim_oldwd)')
-endfunction
-
-
 " Default IsInRCode function when the plugin is used as a global plugin
 function! DefaultIsInRCode(vrb)
     return 1
@@ -89,7 +82,6 @@ call RCreateMaps("ni", '<Plug>RShowRout',     'ao', ':call ShowRout()')
 " Knitr::spin
 " -------------------------------------
 call RCreateMaps("ni", '<Plug>RSpinFile',     'ks', ':call RSpin()')
-call RCreateMaps("ni", '<Plug>RRenderFile',     'kr', ':call RRender()')
 
 call RCreateSendMaps()
 call RControlMaps()

--- a/ftplugin/rmd_nvimr.vim
+++ b/ftplugin/rmd_nvimr.vim
@@ -3,7 +3,6 @@ if exists("g:disable_r_ftplugin")
     finish
 endif
 
-
 " Source scripts common to R, Rrst, Rnoweb, Rhelp and Rdoc:
 runtime R/common_global.vim
 if exists("g:rplugin_failed")
@@ -65,36 +64,6 @@ function! RmdNextChunk() range
     return
 endfunction
 
-function! RMakeRmd(t)
-    update
-
-    if a:t == "odt"
-        if has("win32")
-            let g:rplugin_soffbin = "soffice.exe"
-        else
-            let g:rplugin_soffbin = "soffice"
-        endif
-        if !executable(g:rplugin_soffbin)
-            call RWarningMsg("Is Libre Office installed? Cannot convert into ODT: '" . g:rplugin_soffbin . "' not found.")
-            return
-        endif
-    endif
-
-    let rmddir = expand("%:p:h")
-    if has("win32")
-        let rmddir = substitute(rmddir, '\\', '/', 'g')
-    endif
-    if a:t == "default"
-        let rcmd = 'nvim.interlace.rmd("' . expand("%:t") . '", rmddir = "' . rmddir . '"'
-    else
-        let rcmd = 'nvim.interlace.rmd("' . expand("%:t") . '", outform = "' . a:t .'", rmddir = "' . rmddir . '"'
-    endif
-    if (g:R_openhtml  == 0 && a:t == "html_document") || (g:R_openpdf == 0 && (a:t == "pdf_document" || a:t == "beamer_presentation" || a:t == "word_document"))
-        let rcmd .= ", view = FALSE"
-    endif
-    let rcmd = rcmd . ', envir = ' . g:R_rmd_environment . ')'
-    call g:SendCmdToR(rcmd)
-endfunction
 
 " Send Rmd chunk to R
 function! SendRmdChunkToR(e, m)
@@ -130,12 +99,6 @@ call RCreateMaps("nvi", '<Plug>RSetwd',        'rd', ':call RSetWD()')
 
 " Only .Rmd files use these functions:
 call RCreateMaps("nvi", '<Plug>RKnit',          'kn', ':call RKnit()')
-call RCreateMaps("nvi", '<Plug>RMakeRmd',       'kr', ':call RMakeRmd("default")')
-call RCreateMaps("nvi", '<Plug>RMakePDFK',      'kp', ':call RMakeRmd("pdf_document")')
-call RCreateMaps("nvi", '<Plug>RMakePDFKb',     'kl', ':call RMakeRmd("beamer_presentation")')
-call RCreateMaps("nvi", '<Plug>RMakeWord',      'kw', ':call RMakeRmd("word_document")')
-call RCreateMaps("nvi", '<Plug>RMakeHTML',      'kh', ':call RMakeRmd("html_document")')
-call RCreateMaps("nvi", '<Plug>RMakeODT',       'ko', ':call RMakeRmd("odt")')
 call RCreateMaps("ni",  '<Plug>RSendChunk',     'cc', ':call b:SendChunkToR("silent", "stay")')
 call RCreateMaps("ni",  '<Plug>RESendChunk',    'ce', ':call b:SendChunkToR("echo", "stay")')
 call RCreateMaps("ni",  '<Plug>RDSendChunk',    'cd', ':call b:SendChunkToR("silent", "down")')


### PR DESCRIPTION
See if this does what you want.  I've moved the .Rmd logic to common_global and now .R scripts should be able to be "spun" into .pdf, .html, etc.
